### PR TITLE
Refactor Time.now to Time.current

### DIFF
--- a/lib/acts_as_pushable/active_record/device.rb
+++ b/lib/acts_as_pushable/active_record/device.rb
@@ -23,7 +23,7 @@ module ActsAsPushable
     def deactivate
       self.update_attributes({
         active: false,
-        deactivated_at: Time.now,
+        deactivated_at: Time.current,
       })
     end
 
@@ -40,7 +40,7 @@ module ActsAsPushable
     private
 
     def set_valid_at
-      self.valid_at = Time.now
+      self.valid_at = Time.current
     end
   end
 end

--- a/lib/acts_as_pushable/apn/feedback_service.rb
+++ b/lib/acts_as_pushable/apn/feedback_service.rb
@@ -14,7 +14,7 @@ module ActsAsPushable
 
         devices.each do |device|
           device = ActsAsPushable::Device.find_by_token(device)
-          device.update_attribute('invalidated_at', Time.now) if device
+          device.update_attribute('invalidated_at', Time.current) if device
         end
       end
     end

--- a/lib/acts_as_pushable/gcm/notification.rb
+++ b/lib/acts_as_pushable/gcm/notification.rb
@@ -6,7 +6,7 @@ module ActsAsPushable
       def perform
         response = client.send([device.token], gcm_options)
         if response[:not_registered_ids].include? device.token
-          device.update_attribute 'invalidated_at', Time.now
+          device.update_attribute 'invalidated_at', Time.current
         end
         response
       end

--- a/spec/acts_as_pushable/active_record/device_spec.rb
+++ b/spec/acts_as_pushable/active_record/device_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe ActsAsPushable::Device do
         Timecop.freeze(Time.parse('2016-01-01')) do
           expect(@device.deactivated_at).to be_nil
           @device.deactivate
-          expect(@device.deactivated_at).to eq(Time.now)
+          expect(@device.deactivated_at).to eq(Time.current)
         end
       end
     end

--- a/spec/acts_as_pushable/apn/feedback_service_spec.rb
+++ b/spec/acts_as_pushable/apn/feedback_service_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ActsAsPushable::APN::FeedbackService do
         allow_any_instance_of(Houston::Client).to receive(:devices).and_return(["abc123"])
         ActsAsPushable::APN::FeedbackService.run
         @device.reload
-        expect(@device.invalidated_at).to eq(Time.now)
+        expect(@device.invalidated_at).to eq(Time.current)
       end
     end
   end

--- a/spec/acts_as_pushable/gcm/notification_spec.rb
+++ b/spec/acts_as_pushable/gcm/notification_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ActsAsPushable::GCM::Notification do
           expect_any_instance_of(GCM).to receive(:send).once.and_return({ not_registered_ids: [@device.token] })
           ActsAsPushable::GCM::Notification.send(device: @device, title: 'My App', message: 'this is a test', popup_title: "this is a test")
           @device.reload
-          expect(@device.invalidated_at).to eq(Time.now)
+          expect(@device.invalidated_at).to eq(Time.current)
         end
       end
     end


### PR DESCRIPTION
I think you should use ```.current``` instead of ```.now```.

The difference of ```.current``` and ```.now``` is ```.now``` uses the server's timezone, while ```.current``` uses what the Rails environment is set to. If it's not set, then ```.current``` will be same as ```.now```.

**Time.current**

Returns ```Time.zone.now``` when ```Time.zone``` or ```config.time_zone``` are set, otherwise just returns ```Time.now```. 

**Datetime.current**

Returns ```Time.zone.now.to_datetime``` when ```Time.zone``` or ```config.time_zone``` are set, otherwise returns ```Time.now.to_datetime```.